### PR TITLE
Upgraded version of guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "testdox": "XDEBUG_MODE=coverage phpunit --testdox"
     },
     "require": {
-        "guzzlehttp/guzzle": "^7.1"
+        "guzzlehttp/guzzle": "^7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2de2f4897d08483729e19d829c546f35",
+    "content-hash": "5b2bf0866e3490f2da127ed3b47232ff",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -49,12 +49,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2601,5 +2601,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Upgraded version of guzzlehttp/guzzle to the latest.

```
PHPUnit 9.6.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.33
Configuration: /Users/ryangilreath/Projects/php-sfax/phpunit.xml
Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

...............                                                   15 / 15 (100%)

Time: 00:00.071, Memory: 10.00 MB

OK (15 tests, 27 assertions)
```